### PR TITLE
fix: gset_genome always calls gsetroot, drop memoized session snapshot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: misha.ext
 Title: A home to functions that extend the misha package
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: 
     person(given = "Aviezer",
            family = "Lifshitz",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # misha.ext 0.1.5
 
+* **Database corruption fix:** `gset_genome()` always calls `gsetroot()` now. Its memoized fast path (`force = FALSE`) restored only part of the misha session - leaving the previous genome's chromosome aliases and dataset maps in place, and replaying a track listing that went stale as soon as a track was added. That stale listing could then be written into the current database's `.db.cache`, so every other user of that database saw the wrong tracks. The `force` argument is now ignored and kept only for backward compatibility.
 * Added `gtrack.create_kmer()`: builds a dense k-mer count/fraction track in one call. Whole-hg38 GC-content tracks complete in seconds. Supports multi-kmer summation (e.g. `c("G", "C")` for GC content) and an optional sliding `window`.
 * `gseq.create_track` is now defunct. Use `gtrack.create_kmer` instead - it is faster, produces a dense track, and supports multi-kmer summation and sliding windows.
 

--- a/R/groot.R
+++ b/R/groot.R
@@ -39,10 +39,14 @@ init_config <- function(params_yaml) {
 #'
 #' @param genome name of the genome (e.g. hg19)
 #' @param params_yaml path to .misha.yaml parameters file. By default, \code{misha.ext} would look for such file
-#' @param force force gsetroot call, overwriting exsiting memoized genome
 #' first at the current directory, then at the user's home directory, then at an environment variable called "MISHA_GENOMES"
 #' and if none of the above exist - a new file would be created at the user's home directory. You can run \code{find_params_yaml}
 #' to see the current location of your configuration file.
+#'
+#' @param force ignored, kept for backward compatibility. It used to select a
+#' memoized session snapshot instead of calling \code{gsetroot()}; the snapshot
+#' held only part of the misha session, so restoring it could leave the previous
+#' genome's chromosome aliases, dataset maps and track listing in place.
 #'
 #' @examples
 #' \dontrun{
@@ -55,22 +59,16 @@ gset_genome <- function(genome, params_yaml = find_params_yaml(), force = TRUE) 
     if (is.null(groot)) {
         stop("no genome named ", genome, " in params yaml")
     }
-    if (!exists("global_groots", envir = .misha)) {
-        global_groots <- list()
-    } else {
-        global_groots <- get("global_groots", envir = .misha)
+    # Always go through gsetroot(). The old memoized fast path restored only
+    # ALLGENOME/GROOT/GWD/GTRACKS/GINTERVS, leaving CHROM_ALIAS,
+    # DB_IS_PER_CHROMOSOME, GDATASETS and GTRACK_DATASET pointing at the
+    # previously loaded genome, and it replayed a snapshot that went stale as
+    # soon as a track was added. gsetroot() reads the on-disk .db.cache, so it
+    # is fast anyway.
+    if (exists("global_groots", envir = .misha)) {
+        rm("global_groots", envir = .misha)
     }
-    if (is.null(global_groots[[genome]]) || force) {
-        gsetroot(groot)
-        global_groots[[genome]] <- list(ALLGENOME = .misha$ALLGENOME, GROOT = .misha$GROOT, GWD = .misha$GWD, GTRACKS = .misha$GTRACKS, GINTERVS = .misha$GINTERVS)
-    } else {
-        assign("ALLGENOME", global_groots[[genome]][["ALLGENOME"]], envir = .misha)
-        assign("GROOT", global_groots[[genome]][["GROOT"]], envir = .misha)
-        assign("GWD", global_groots[[genome]][["GWD"]], envir = .misha)
-        assign("GTRACKS", global_groots[[genome]][["GTRACKS"]], envir = .misha)
-        assign("GINTERVS", global_groots[[genome]][["GINTERVS"]], envir = .misha)
-    }
-    assign("global_groots", global_groots, envir = .misha)
+    gsetroot(groot)
 }
 
 get_genome <- function(genome, params_yaml) {

--- a/man/genome_exists.Rd
+++ b/man/genome_exists.Rd
@@ -9,7 +9,10 @@ genome_exists(genome, params_yaml = find_params_yaml())
 \arguments{
 \item{genome}{name of the genome (e.g. hg19)}
 
-\item{params_yaml}{path to .misha.yaml parameters file. By default, \code{misha.ext} would look for such file}
+\item{params_yaml}{path to .misha.yaml parameters file. By default, \code{misha.ext} would look for such file
+first at the current directory, then at the user's home directory, then at an environment variable called "MISHA_GENOMES"
+and if none of the above exist - a new file would be created at the user's home directory. You can run \code{find_params_yaml}
+to see the current location of your configuration file.}
 }
 \description{
 Does a genome db exist at the config file

--- a/man/gset_genome.Rd
+++ b/man/gset_genome.Rd
@@ -12,12 +12,15 @@ gset_genome(genome, params_yaml = find_params_yaml(), force = TRUE)
 \arguments{
 \item{genome}{name of the genome (e.g. hg19)}
 
-\item{params_yaml}{path to .misha.yaml parameters file. By default, \code{misha.ext} would look for such file}
-
-\item{force}{force gsetroot call, overwriting exsiting memoized genome
+\item{params_yaml}{path to .misha.yaml parameters file. By default, \code{misha.ext} would look for such file
 first at the current directory, then at the user's home directory, then at an environment variable called "MISHA_GENOMES"
 and if none of the above exist - a new file would be created at the user's home directory. You can run \code{find_params_yaml}
 to see the current location of your configuration file.}
+
+\item{force}{ignored, kept for backward compatibility. It used to select a
+memoized session snapshot instead of calling \code{gsetroot()}; the snapshot
+held only part of the misha session, so restoring it could leave the previous
+genome's chromosome aliases, dataset maps and track listing in place.}
 }
 \description{
 Set misha root based on genome name


### PR DESCRIPTION
Companion to [tanaylab/misha#154](https://github.com/tanaylab/misha/pull/154). That PR contains the damage; this one removes the trigger.

## Problem

`gset_genome(genome, force = FALSE)` skipped `gsetroot()` and instead replayed a snapshot taken at the last `gsetroot()` call:

```r
list(ALLGENOME = .misha$ALLGENOME, GROOT = .misha$GROOT, GWD = .misha$GWD,
     GTRACKS = .misha$GTRACKS, GINTERVS = .misha$GINTERVS)
```

Two things wrong with that.

**It restores only part of the session.** `CHROM_ALIAS`, `DB_IS_PER_CHROMOSOME`, `GDATASETS` and `GTRACK_DATASET` are left pointing at whichever genome was loaded before the restore, so a "restored" genome can be carrying the previous genome's chromosome aliases and dataset maps.

**The snapshot goes stale.** It is taken once and never updated, so any track created after it is invisible on restore. Worse, misha persists the in-memory listing to `<groot>/.db.cache` on every track add/remove - so that stale listing gets written to disk, and every other user of the database reads it back. Reproduced on temporary databases: a track that existed on disk vanished from `gtrack.ls()` for everyone.

## Fix

Always call `gsetroot()`. It reads the on-disk `.db.cache`, so it was never the slow path the memo was avoiding. `force` is accepted and ignored so existing callers keep working, and any leftover `global_groots` is dropped from `.misha` for long-running sessions.

## Verification

Two temp databases with different genomes, driven through `gset_genome` both ways:

```
gset_genome(gA)                GROOT=dbA  chroms=chrA  GTRACKS=trackA
gset_genome(gB)                GROOT=dbB  chroms=chrB  GTRACKS=trackB
gset_genome(gA, force=FALSE)   GROOT=dbA  chroms=chrA  GTRACKS=trackA
gset_genome(gB, force=FALSE)   GROOT=dbB  chroms=chrB  GTRACKS=trackB
sees added_later after restore: TRUE
```

The last line is the old failure: a track created after the memo was taken used to disappear on restore and then get flushed out of `.db.cache`.

Also bumps to 0.1.5 so this can be released to conda.

https://claude.ai/code/session_01GAEMstkQFr1xu1drZ75juv
