### PR TITLE
ci: install conda-build into base so `conda build` resolves

### DIFF
--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -26,7 +26,8 @@ jobs:
           miniforge-version: latest
           channels: conda-forge,aviezerl
           channel-priority: strict
-          activate-environment: build
+          activate-environment: base
+          auto-activate: true
 
       - name: Install conda-build and anaconda-client
         run: |


### PR DESCRIPTION
The v0.1.5 conda build [failed](https://github.com/tanaylab/misha.ext/actions/runs/31677964744) after 47s:

```
environment location: /home/runner/miniconda3/envs/build
...
conda: error: argument COMMAND: invalid choice: 'build'
```

`setup-miniconda` was told to create a separate `build` environment, so `conda install conda-build anaconda-client` installed into `envs/build` - but the `conda` executable resolves its subcommands from **base**, so `conda build` did not exist. The upload step then found no packages and failed too.

Switches to `activate-environment: base` + `auto-activate: true`, matching [tanaylab/misha's workflow](https://github.com/tanaylab/misha/blob/master/.github/workflows/conda-publish.yml), which builds and publishes successfully.

Once merged, v0.1.5 needs a manual `workflow_dispatch` run (version `0.1.5`) - the existing tag points at the commit before this fix.

https://claude.ai/code/session_01GAEMstkQFr1xu1drZ75juv